### PR TITLE
Added inline panels and improved admin functionality

### DIFF
--- a/evently/admin.py
+++ b/evently/admin.py
@@ -1,20 +1,49 @@
+from django.urls import reverse
+from django.utils.html import format_html
 from django.contrib import admin
 from .models import Status, CreateUserModel, Comment, Category, Event
 
 
+# Inlajnowe panele
+class CommentInline(admin.TabularInline):
+    model = Comment
+    extra = 0  # Ilość pustych formularzy do dodawania nowych komentarzy
+    fields = ('event', 'content', 'event_date', 'delete_link')
+    readonly_fields = ('event', 'content', 'event_date', 'delete_link',)  # Tylko dla odczytywania
+
+    def delete_link(self, obj):
+        delete_url = reverse('admin:%s_%s_delete' % (obj._meta.app_label, obj._meta.model_name), args=[obj.pk])
+        return format_html('<a href="{}">Delete</a>', delete_url)
+    delete_link.allow_tags = True
+    delete_link.short_description = 'Actions'
+
+
+class EventInline(admin.TabularInline):
+    model = Event
+    extra = 0  # Ilość pustych formularzy do dodawania nowych wydarzeń
+    readonly_fields = ('added', 'modified')  # Tylko dla odczytywania
+
+
+
+# Zawartość PA
 class CreateUserModelAdmin(admin.ModelAdmin):
     list_display = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff')
     search_fields = ('username', 'email', 'first_name', 'last_name')
     list_filter = ('is_active', 'is_staff', 'is_superuser', 'groups')
+    inlines = [CommentInline, EventInline] # in-line panele dla komentarzy oraz wydarzeń
 
 
 class EventAdmin(admin.ModelAdmin):
     list_display = (
-        'name', 'author', 'place', 'start_at', 'end_at', 'status', 'category_list', 'description', 'added', 'modified')
+        'name', 'author', 'place', 'start_at', 'end_at', 'status', 'category_list', 'added', 'modified')
     search_fields = ('name', 'author', 'place', 'start_at', 'end_at', 'status', 'description')
     list_filter = ('status', 'place', 'start_at', 'end_at')
     ordering = ('-start_at',)
     date_hierarchy = 'start_at'
+
+    # optymizacja BD(JOIN author+status)
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('author', 'status')
 
 
 class StatusAdmin(admin.ModelAdmin):
@@ -26,9 +55,14 @@ class StatusAdmin(admin.ModelAdmin):
 
 
 class CommentAdmin(admin.ModelAdmin):
-    list_display = ('author', 'event', 'event_date', 'content', 'added', 'modified')
+    list_display = ('author_link', 'author', 'event', 'event_date', 'content', 'added', 'modified')
     search_fields = ('author', 'event', 'event_date', 'content')
     list_filter = ('added', 'modified')
+
+    def author_link(self, obj):
+        url = reverse('admin:%s_%s_change' % (obj.author._meta.app_label, obj.author._meta.model_name), args=[obj.author.pk])
+        return format_html('<a href="{}">{}</a>', url, obj.author)
+    author_link.short_description = 'Author'
 
 
 class CategoryAdmin(admin.ModelAdmin):

--- a/evently/models.py
+++ b/evently/models.py
@@ -47,7 +47,7 @@ class Event(models.Model):
         return f'Event: {self.name}, start at: {self.start_at}, end at: {self.end_at}'
     # dla panelu administratora(żeby poprawnie wyswietliwało się many-to-many)
     def category_list(self):
-        return "".join([category.name for category in self.category.all()])
+        return ", ".join([category.name for category in self.category.all()])
     category_list.short_description = 'Category'
 
 

--- a/evently/views.py
+++ b/evently/views.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -220,8 +220,6 @@ def user_profile(request):
     return render(request, 'profile.html', {'user': user})
 
 
-
-
 # wykonaj zapytanie do bazy danych, aby uzyskać wszystkie obiekty Event, w których bieżący użytkownik znajduje się na liście uczestników.
 @login_required
 def user_subscriptions(request, pk):
@@ -293,8 +291,8 @@ def send_test_email(request):
             temat = form.cleaned_data.get('subject', 'Brak tematu')
             tresc_tekstowa = form.cleaned_data.get('message_text', 'Brak treści').replace('\n', '<br>')
             send_to_all = form.cleaned_data.get('send_to_all', False)
+            # Wysyłanie do wszystkich użytkowników
             if send_to_all:
-                # Wysyłanie do wszystkich użytkowników
                 recipients = CreateUserModel.objects.all()
                 for user in recipients:
                     html_content = f"""


### PR DESCRIPTION
This pull request introduces several improvements to the Django admin interface:

- **Inline Panels**: Added `CommentInline` and `EventInline` panels to the `CreateUserModelAdmin` admin class. This change allows administrators to view and manage related comments and events directly on the user detail page.
- **Delete Link**: Implemented a `delete_link` method in `CommentInline` that provides a direct link to delete comments from the inline panel.
- **Author Link**: Updated the `CommentAdmin` class to include a clickable link to the author's detail page, making it easier to view all comments by a specific user.
- **Queryset Optimization**: Enhanced `EventAdmin` by using `select_related` to optimize database queries for related `author` and `status` fields.
- **Usability Improvements**: Adjusted `list_display` in `CommentAdmin` to include `author_link` for better navigation.

These modifications are aimed at improving the efficiency and usability of the admin interface for managing users, comments, and events.