### PR TITLE
feat: Add delete comment functionality for users and admins

### DIFF
--- a/Projekt_Koncowy/urls.py
+++ b/Projekt_Koncowy/urls.py
@@ -19,7 +19,7 @@ from django.urls import path
 import django.contrib.auth.views as auth_views
 
 from evently.views import create_event, UserCreateView, CreateCategoryView, list_events, subscribe_event, \
-    search_event, edit_event, delete_event, full_event_description, unsubscribe_event, linkedlin_Roger, \
+    search_event, edit_event, delete_event, full_event_description, unsubscribe_event,delete_comment,  linkedlin_Roger, \
     linkedlin_Artema, user_profile, user_subscriptions, homepage, admin_status_view, update_event_status, send_test_email
 
 urlpatterns = [
@@ -41,6 +41,7 @@ urlpatterns = [
     path('full_event_description/<int:pk>/', full_event_description, name='full_event_description'),
     path('subscribe_event/<int:event_id>/', subscribe_event, name='subscribe_event'),
     path('event/<int:pk>/unregister/', unsubscribe_event, name='unsubscribe_event'),
+    path('delete_comment/<int:pk>/', delete_comment, name='delete_comment'),
     # user
     path('createuser/', UserCreateView.as_view(), name='user'),
     path('accounts/login/', auth_views.LoginView.as_view(), name='login'),

--- a/evently/views.py
+++ b/evently/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import render, redirect, get_object_or_404
@@ -227,6 +228,17 @@ def user_subscriptions(request, pk):
     subscribed_events = Event.objects.filter(participants=user)
     return render(request, 'user_subscriptions.html', {'subscribed_events': subscribed_events})
 
+# Usuwanie komentarzy dal userów oraz adminów
+@login_required
+def delete_comment(request, pk):
+    comment = get_object_or_404(Comment, pk=pk)
+    if request.user == comment.author or request.user.is_superuser:
+        comment.delete()
+        messages.success(request, "Comment has been deleted successfully.")
+    else:
+        messages.error(request, "You do not have permission to delete this comment.")
+
+    return redirect('full_event_description', comment.event.id)
 
 def linkedlin_Roger(request):
     response = redirect('https://www.linkedin.com/in/rogerszwaja')

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,6 +58,15 @@
 
 <!-- Treść strony głównej -->
 <main class="container mt-4">
+    <!-- Pokaz messages -->
+    {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
     {% block content %}
     {% endblock %}
 </main>

--- a/templates/delete_comment.html
+++ b/templates/delete_comment.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="container mt-4">
+        <h1>Delete this comment</h1>
+        <p>Are you sure you want to delete the comment?</p>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger" style="background-color: red; border-color: red;">Delete</button>
+            <a href="{% url 'full_event_description' comment.event.id %}" class="btn btn-secondary">Cancel</a>
+        </form>
+    </div>
+{% endblock %}

--- a/templates/full_event_description.html
+++ b/templates/full_event_description.html
@@ -64,13 +64,15 @@
             <div class="comments-list">
                 {% for comment in comments %}
                     <div class="comment">
-                        <table>
-                            <td>
-                                <p><strong>{{ comment.author.username }}</strong></p>
-                                <p>{{ comment.content }}</p>
-                                <p><small>{{ comment.added }}</small></p>
-                            </td>
-                        </table>
+                        <p><strong>{{ comment.author.username }}</strong></p>
+                        <p>{{ comment.content }}</p>
+                        <p><small>{{ comment.added }}</small></p>
+                        {% if comment.author == user or user.is_staff %}
+                            <form action="{% url 'delete_comment' comment.id %}" method="post" style="display:inline;">
+                                {% csrf_token %}
+                                <button type="submit" style="background-color: red; color: white; padding: 5px 10px; font-size: 12px; border: none; border-radius: 3px;">Delete</button>
+                            </form>
+                        {% endif %}
                     </div>
                 {% empty %}
                     <p>No comments yet. Be the first to comment!</p>

--- a/templates/search_results_list.html
+++ b/templates/search_results_list.html
@@ -34,7 +34,7 @@
         </tr>
         <tr style="height: 200px;"></tr> <!--duży odstęp -->
 
-    {% empty %} Pozwala obsluzyc przypadek gdy iterowana lista jest pusta
+    {% empty %} <!-- Pozwala obsluzyc przypadek gdy iterowana lista jest pusta -->
         <tr>
             <td colspan="6">No results match your search criteria</td>
             <!-- Brak wyników spełniających kryteria wyszukiwania -->


### PR DESCRIPTION
# Add delete comment functionality

## Overview

This pull request introduces the ability for users to delete their own comments and for admins to delete any comments within the application. The new feature includes:

- A delete button next to each comment.
- CSRF protection for the delete action.
- The delete button is styled to be red and small to improve user interface and conserve space.

## Changes

- Updated `full_event_description.html` to include a delete button for comments.
- Added conditional logic to display the delete button only for the comment's author or admins.
- Applied inline styling and custom classes to resize and color the delete button.

## Why this feature?

Allowing users and admins to manage comments directly enhances the usability of the application and gives better control over content.